### PR TITLE
Fix missing hyperlinks

### DIFF
--- a/_includes/navbar-content.en.html
+++ b/_includes/navbar-content.en.html
@@ -25,7 +25,7 @@
           <li><a href="{{ upper_level }}"><i class="fa fa-arrow-circle-up"></i> Up one level</a></li>
         {% endif %}
         <li>
-          <a href="https://github.com/red-data-tools/red-data-tools"><i class="fa fa-github"></i> GitHub</a>
+          <a href="https://github.com/red-data-tools"><i class="fa fa-github"></i> GitHub</a>
         </li>
       </ul>
     </div>

--- a/_includes/navbar-content.ja.html
+++ b/_includes/navbar-content.ja.html
@@ -25,7 +25,7 @@
           <li><a href="{{ upper_level }}"><i class="fa fa-arrow-circle-up"></i> Up one level</a></li>
         {% endif %}
         <li>
-          <a href="https://github.com/red-data-tools/red-data-tools"><i class="fa fa-github"></i> GitHub</a>
+          <a href="https://github.com/red-data-tools"><i class="fa fa-github"></i> GitHub</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
https://github.com/red-data-tools/red-data-tools becomes to 404.

I think https://github.com/red-data-tools is better link target.
