### PR TITLE
Add upper_level explicitly to fix broken up link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,7 @@ defaults:
       type: posts
     values:
       path_prefix: /ja/blog/
+      upper_level: /ja/blog/
       layout: post
       language: ja
       country: JP
@@ -39,6 +40,7 @@ defaults:
       type: posts
     values:
       path_prefix: /blog/
+      upper_level: /blog/
       layout: post
       language: en
       country: US

--- a/ja/blog/index.md
+++ b/ja/blog/index.md
@@ -1,5 +1,6 @@
 ---
 title: Red Data Toolsブログ
+upper_level: /ja/blog/
 ---
 
 # Red Data Toolsブログ

--- a/ja/blog/index.md
+++ b/ja/blog/index.md
@@ -1,6 +1,5 @@
 ---
 title: Red Data Toolsブログ
-upper_level: /ja/blog/
 ---
 
 # Red Data Toolsブログ


### PR DESCRIPTION
Another try.
Set `upper_level` in yaml front matter explicitly, the up link works well.

BTW, post url without `blog` is intentional?
(URL is not `/ja/blog/2018/01/08/red-datasets-0-0-1.html`,
but `/ja/2018/01/08/red-datasets-0-0-1.html`)